### PR TITLE
Add support for gitlab.com packages

### DIFF
--- a/go2port.go
+++ b/go2port.go
@@ -473,6 +473,9 @@ func rawFileUrl(pkg Package, dir string, file string) (string, error) {
 	case "git.sr.ht":
 		return fmt.Sprintf("https://git.sr.ht/%s/%s/blob/%s/%s/%s",
 			pkg.Author, pkg.Project, pkg.Version, dir, file), nil
+	case "gitlab.com":
+		return fmt.Sprintf("https://gitlab.com/%s/%s/-/raw/%s/%s/%s",
+			pkg.Author, pkg.Project, pkg.Version, dir, file), nil
 	default:
 		return "", errors.New(fmt.Sprintf("Unsupported domain: %s", pkg.Host))
 	}


### PR DESCRIPTION
Tested this while updating the glab package, which has recently moved to GitLab https://github.com/profclems/glab/issues/983.